### PR TITLE
bugfix/fix-invalid-dockercompose

### DIFF
--- a/src/Elsa.Samples.UserRegistration/docker-compose.yaml
+++ b/src/Elsa.Samples.UserRegistration/docker-compose.yaml
@@ -5,7 +5,6 @@ services:
     image: mongo
     ports:
     - "27017:27017"
-    - 
   smtp4dev:
     image: rnwood/smtp4dev:linux-amd64-3.1.0-ci0856
     ports:


### PR DESCRIPTION
Removes invalid list item under mongodb port listing in docker-compose definition. 