### PR TITLE
Add hosted Blazor WASM app with tenant-aware configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,6 +74,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.1"/>
     <PackageVersion Include="Microsoft.JSInterop" Version="9.0.1" />
     <PackageVersion Include="AutoMapper" Version="13.0.1" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />

--- a/Elsa.Samples.sln
+++ b/Elsa.Samples.sln
@@ -138,6 +138,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElsaStudioDesignerRehostedA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElsaStudioBlazorWebAssemblyApp", "src\blazor\ElsaStudioBlazorWebAssemblyApp\ElsaStudioBlazorWebAssemblyApp.csproj", "{3BD6F27E-6108-4D69-A9F6-445DFF8CD59E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElsaStudioBlazorWebAssemblyAppHost", "src\blazor\ElsaStudioBlazorWebAssemblyAppHost\ElsaStudioBlazorWebAssemblyAppHost\ElsaStudioBlazorWebAssemblyAppHost.csproj", "{562F80BE-D5BF-4F98-A582-6F9D9C4D7678}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -202,6 +204,7 @@ Global
 		{7CCE7D85-95C6-4CE8-A578-D392AB1CA714} = {BA2E38F3-A073-4D60-AE4C-B098FD87C997}
 		{EB2596D5-EBB5-48D7-A78E-F2C904761291} = {A548F792-8343-446D-B21F-EE7C14E3472A}
 		{3BD6F27E-6108-4D69-A9F6-445DFF8CD59E} = {A548F792-8343-446D-B21F-EE7C14E3472A}
+		{562F80BE-D5BF-4F98-A582-6F9D9C4D7678} = {A548F792-8343-446D-B21F-EE7C14E3472A}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3E156F62-ED0C-4D02-893E-D04E5EB05F9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -404,5 +407,9 @@ Global
 		{3BD6F27E-6108-4D69-A9F6-445DFF8CD59E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BD6F27E-6108-4D69-A9F6-445DFF8CD59E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BD6F27E-6108-4D69-A9F6-445DFF8CD59E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{562F80BE-D5BF-4F98-A582-6F9D9C4D7678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{562F80BE-D5BF-4F98-A582-6F9D9C4D7678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{562F80BE-D5BF-4F98-A582-6F9D9C4D7678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{562F80BE-D5BF-4F98-A582-6F9D9C4D7678}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/blazor/ElsaStudioBlazorWebAssemblyApp/Program.cs
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyApp/Program.cs
@@ -12,6 +12,7 @@ using Elsa.Studio.Shell.Extensions;
 using Elsa.Studio.WorkflowContexts.Extensions;
 using Elsa.Studio.Workflows.Designer.Extensions;
 using Elsa.Studio.Workflows.Extensions;
+using ElsaStudioBlazorWebAssemblyApp.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
@@ -25,7 +26,18 @@ builder.RootComponents.RegisterCustomElsaStudioElements();
 var backendApiConfig = new BackendApiConfig
 {
     ConfigureBackendOptions = options => configuration.GetSection("Backend").Bind(options),
-    ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(AuthenticatingApiHttpMessageHandler), 
+    ConfigureHttpClientBuilder = options =>
+    {
+        options.AuthenticationHandler = typeof(AuthenticatingApiHttpMessageHandler);
+        options.ConfigureHttpClient = (sp, httpClient) =>
+        {
+            var tenantIdAccessor = sp.GetRequiredService<TenantIdAccessor>();
+            var tenantId = tenantIdAccessor.GetTenantIdFromUrl();
+            
+            if (tenantId != null)
+                httpClient.DefaultRequestHeaders.Add("X-Company-Id", tenantId);
+        };
+    },
 };
 
 builder.Services.AddCore();
@@ -36,6 +48,7 @@ builder.Services.AddDashboardModule();
 builder.Services.AddWorkflowsModule();
 builder.Services.AddWorkflowContextsModule();
 builder.Services.AddScoped<ITimeZoneProvider, LocalTimeZoneProvider>();
+builder.Services.AddSingleton<TenantIdAccessor>();
 
 var app = builder.Build();
 var startupTaskRunner = app.Services.GetRequiredService<IStartupTaskRunner>();

--- a/src/blazor/ElsaStudioBlazorWebAssemblyApp/Properties/launchSettings.json
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyApp/Properties/launchSettings.json
@@ -1,38 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8673",
-      "sslPort": 44344
-    }
-  },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "http://localhost:5230",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7198;http://localhost:5230",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7198",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/blazor/ElsaStudioBlazorWebAssemblyApp/Services/TenantIdAccessor.cs
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyApp/Services/TenantIdAccessor.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Components;
+
+namespace ElsaStudioBlazorWebAssemblyApp.Services;
+
+public class TenantIdAccessor(NavigationManager navigationManager)
+{
+    public string? GetTenantIdFromUrl()
+    {
+        // Extract tenant ID from the URL.
+        var uri = new Uri(navigationManager.Uri);
+        var segments = uri.AbsolutePath.Trim('/').Split('/');
+
+        // Example: Tenant ID is the first path segment.
+        return segments.Length > 0 ? segments[0] : null;
+    }
+}

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost.csproj
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="wwwroot\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\ElsaStudioBlazorWebAssemblyApp\ElsaStudioBlazorWebAssemblyApp.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Middleware/WasmAssetsRewritingMiddleware.cs
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Middleware/WasmAssetsRewritingMiddleware.cs
@@ -1,0 +1,63 @@
+namespace ElsaStudioBlazorWebAssemblyAppHost.Middleware;
+
+/// <summary>
+/// Middleware that intercepts HTTP requests and rewrites specific asset-related paths
+/// for Web Assembly applications to ensure proper routing and handling of static files.
+/// </summary>
+public class WasmAssetsRewritingMiddleware(RequestDelegate next, ILogger<WasmAssetsRewritingMiddleware> logger)
+{
+    private static readonly string[] TargetSegments = { "_content", "_framework" };
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.Request.Path.HasValue && NeedsRewriting(context.Request.Path.Value!))
+        {
+            var path = context.Request.Path.Value!;
+        
+            // Call the private method to get the index of the target segment using spans
+            var segmentIndex = GetTargetSegmentIndex(path.AsSpan());
+        
+            if (segmentIndex > 0)
+            {
+                // Use slices instead of Substring to avoid allocations
+                var newPath = path.AsSpan(segmentIndex).ToString(); // Convert back to a string only when required
+                context.Request.Path = newPath.StartsWith('/') ? newPath : $"/{newPath}";
+
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Rewritten: {Path} -> {NewPath}", path, context.Request.Path.Value);
+            }
+        }
+
+        // Call the next middleware in the pipeline
+        await next(context);
+    }
+
+    private static bool NeedsRewriting(string path)
+    {
+        // Fast path: Return if the path does not include potential target segments
+        foreach (var segment in TargetSegments)
+        {
+            if (path.Contains(segment, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+    
+    private static int GetTargetSegmentIndex(ReadOnlySpan<char> path)
+    {
+        foreach (var segment in TargetSegments)
+        {
+            // Use Span instead of string concatenation and index search
+            var segmentAsSpan = $"{segment}/".AsSpan();
+            var index = path.IndexOf(segmentAsSpan, StringComparison.OrdinalIgnoreCase);
+
+            if (index >= 0)
+            {
+                return index;
+            }
+        }
+
+        return -1; // No valid index found
+    }
+
+}

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Pages/_Host.cshtml
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Pages/_Host.cshtml
@@ -1,0 +1,81 @@
+﻿@page "/"
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@inject IConfiguration Configuration;
+@{
+    var apiUrl = Configuration["Hosting:ApiUrl"];
+    
+    // Get the first segment of the request path, which represents the tenant ID.
+    var segments = Request.Path.Value!.Split('/');
+    var tenantId = segments.Length > 1 ? segments[1] : null;
+    var baseRef = tenantId != null ? $"/{tenantId}/" : "/";
+}
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+    <title>Elsa Studio 3.0</title>
+    <base href="@baseRef"/>
+    <link rel="apple-touch-icon" sizes="180x180" href="_content/Elsa.Studio.Shell/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="_content/Elsa.Studio.Shell/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="_content/Elsa.Studio.Shell/favicon-16x16.png">
+    <link rel="manifest" href="_content/Elsa.Studio.Shell/site.webmanifest">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Grandstander:wght@100&display=swap" rel="stylesheet">
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet"/>
+    <link href="_content/CodeBeam.MudBlazor.Extensions/MudExtensions.min.css" rel="stylesheet"/>
+    <link href="_content/Radzen.Blazor/css/material-base.css" rel="stylesheet">
+    <link href="_content/Elsa.Studio.Shell/css/shell.css" rel="stylesheet">
+    <link href="ElsaStudioBlazorWebAssemblyApp.styles.css" rel="stylesheet">
+</head>
+
+<body>
+<div id="app">
+    <div class="loading-splash mud-container mud-container-maxwidth-false">
+        <h5 class="mud-typography mud-typography-h5 mud-primary-text my-6">Loading...</h5>
+    </div>
+</div>
+
+<div id="blazor-error-ui">
+    An unhandled error has occurred.
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">🗙</a>
+</div>
+<script src="_content/BlazorMonaco/jsInterop.js"></script>
+<script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/loader.js"></script>
+<script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/editor/editor.main.js"></script>
+<script src="_content/MudBlazor/MudBlazor.min.js"></script>
+<script src="_content/CodeBeam.MudBlazor.Extensions/MudExtensions.min.js"></script>
+<script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
+<script>
+    window.getClientConfig = function() { return {
+        "apiUrl": "@apiUrl"
+     } };
+</script>
+<script src="_framework/blazor.webassembly.js" autostart="false"></script>
+
+<script type="application/javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+        Blazor.start({
+            loadBootResource: function (type, name, defaultUri, integrity) {
+                if (defaultUri.startsWith('http'))
+                    return defaultUri;
+
+                if (!defaultUri.startsWith('/'))
+                    return `/${defaultUri}`;
+
+                return defaultUri;
+            }
+        });
+    });
+</script>
+</body>
+
+</html>

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Program.cs
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Program.cs
@@ -1,0 +1,44 @@
+using ElsaStudioBlazorWebAssemblyAppHost.Middleware;
+using Microsoft.AspNetCore.StaticFiles;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseStaticWebAssets();
+
+// Add services to the container.
+builder.Services.AddRazorPages();
+builder.Services.AddCors(cors => cors.AddDefaultPolicy(policy => policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseBlazorFrameworkFiles();
+app.UseRouting();
+app.UseCors();
+
+// Insert this BEFORE UseStaticFiles middleware.
+app.UseMiddleware<WasmAssetsRewritingMiddleware>();
+
+// Use Static Files instead of MapStaticAssets.
+app.UseStaticFiles(new StaticFileOptions
+{
+    ContentTypeProvider = new FileExtensionContentTypeProvider
+    {
+        Mappings =
+        {
+            // Add custom MIME type mappings for WASM
+            [".dat"] = "application/octet-stream"
+        }
+    }
+});
+
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Properties/launchSettings.json
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+    "profiles": {
+      "https": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": false,
+        "applicationUrl": "https://localhost:7168",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      }
+    }
+  }

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/appsettings.Development.json
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/appsettings.json
+++ b/src/blazor/ElsaStudioBlazorWebAssemblyAppHost/ElsaStudioBlazorWebAssemblyAppHost/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Hosting": {
+    "ApiUrl": "https://localhost:5001/elsa/api"
+  }
+}

--- a/src/blazor/ElsaStudioDesignerRehostedApp/ElsaStudioDesignerRehostedApp.csproj
+++ b/src/blazor/ElsaStudioDesignerRehostedApp/ElsaStudioDesignerRehostedApp.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
         <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
     </PropertyGroup>
 


### PR DESCRIPTION
Introduced a new hosted Blazor WebAssembly project to support multi-tenant scenarios, including a tenant-aware middleware and service. Added configuration files, static asset routing improvements, and logic for injecting tenant-specific headers into HTTP requests. Updated solution and project dependencies accordingly.
